### PR TITLE
v12 LTS compatibility changes.

### DIFF
--- a/Classes/Middleware/LoggingMiddleware.php
+++ b/Classes/Middleware/LoggingMiddleware.php
@@ -22,10 +22,7 @@ final class LoggingMiddleware implements MiddlewareInterface, LoggerAwareInterfa
 {
     use LoggerAwareTrait;
 
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger = null;
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
   ],
   "require": {
     "php": "^7.4 || ^8.0",
-    "typo3/cms-core": "^10.4 || ^11.5 || ^12.1",
-    "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.1",
+    "typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
+    "typo3/cms-extbase": "^10.4 || ^11.5 || ^12.4",
     "symfony/messenger": "^5.0 || ^6.2",
     "symfony/options-resolver": "^5.0 || ^6.2",
     "symfony/doctrine-messenger": "^5.0 || ^6.2",
-    "psr/cache": "^1.0",
-    "ssch/typo3-psr-cache-adapter": "^1.1"
+    "psr/cache": "^1.0 || ^2.0",
+    "ssch/typo3-psr-cache-adapter": "^1.2"
   },
   "require-dev": {
     "symplify/easy-coding-standard": "^11.1",
@@ -33,10 +33,10 @@
     "phpstan/phpstan-strict-rules": "^1.4",
     "saschaegerer/phpstan-typo3": "^1.8",
     "phpstan/extension-installer": "^1.2",
-    "typo3/testing-framework": "^6.16",
-    "helhum/typo3-console": "^7.1",
-    "typo3/minimal": "^10.4 || ^11.5 || ^12.0",
-    "typo3/cms-lowlevel": "^10.4 || ^11.5 || ^12.0",
+    "typo3/testing-framework": "^6.16 || ^8.0",
+    "helhum/typo3-console": "^7.1 || ^8.0",
+    "typo3/minimal": "^10.4 || ^11.5 || ^12.4",
+    "typo3/cms-lowlevel": "^10.4 || ^11.5 || ^12.4",
     "symfony/serializer": "^5.0 || ^6.2"
   },
   "replace": {


### PR DESCRIPTION
In order to be able to install this extension in TYPO3 v12 I had to upgrade "psr/cache" to ^2.0 for symfony/cache:6.2 requires at least psr/cache:^2.

Since [ssch/typo3-psr-cache-adapter](https://github.com/sabbelasichon/typo3-psr-cache-adapter) also sets its constraints to "psr/cache": "^1.0" I'll also create a PR in this package allowing "psr/cache": "^1.0 || ^2.0" in a few minutes.

