### PR TITLE
TASK: Fix explicit nullable parameters

### DIFF
--- a/Classes/Mailer/MessengerMailer.php
+++ b/Classes/Mailer/MessengerMailer.php
@@ -56,7 +56,7 @@ final class MessengerMailer implements MailerInterface
         $this->bus = $bus;
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): void
+    public function send(RawMessage $message, ?Envelope $envelope = null): void
     {
         $this->mailValidityResolver->resolve($message);
 

--- a/Classes/Transport/DoctrineTransportWrapper.php
+++ b/Classes/Transport/DoctrineTransportWrapper.php
@@ -54,7 +54,7 @@ final class DoctrineTransportWrapper implements TransportInterface, SetupableTra
         $this->doctrineTransport->setup();
     }
 
-    public function all(int $limit = null): iterable
+    public function all(?int $limit = null): iterable
     {
         return $this->doctrineTransport->all($limit);
     }

--- a/Tests/Functional/Helper/MailerAssertionsTrait.php
+++ b/Tests/Functional/Helper/MailerAssertionsTrait.php
@@ -18,7 +18,7 @@ use Symfony\Component\Mime\Test\Constraint as MimeConstraint;
 
 trait MailerAssertionsTrait
 {
-    public function assertQueuedEmailCount(int $count, string $transport = null, string $message = ''): void
+    public function assertQueuedEmailCount(int $count, ?string $transport = null, string $message = ''): void
     {
         self::assertThat(
             $this->getMessageMailerEvents(),
@@ -40,13 +40,13 @@ trait MailerAssertionsTrait
     /**
      * @return RawMessage[]
      */
-    public function getMailerMessages(string $transport = null): array
+    public function getMailerMessages(?string $transport = null): array
     {
         return $this->getMessageMailerEvents()
             ->getMessages($transport);
     }
 
-    public function getMailerMessage(int $index = 0, string $transport = null): ?RawMessage
+    public function getMailerMessage(int $index = 0, ?string $transport = null): ?RawMessage
     {
         return $this->getMailerMessages($transport)[$index] ?? null;
     }


### PR DESCRIPTION
Make parameters excplicitely nullable for PHP 8.4. This prevents some warnings in logs.